### PR TITLE
fix: Add display language, derived supported language from displaylang.json, improve locale detection

### DIFF
--- a/src/locale/displayLang.json
+++ b/src/locale/displayLang.json
@@ -113,6 +113,12 @@
       "value": "ja",
       "dir": "ltr",
       "disabled": false
+    },
+    {
+      "label": "한국어",
+      "value": "ko",
+      "dir": "ltr",
+      "disabled": false
     }
   ]
 }

--- a/src/locale/displayLang.json
+++ b/src/locale/displayLang.json
@@ -13,14 +13,32 @@
       "disabled": false
     },
     {
+      "label": "Deutsch",
+      "value": "de",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
       "label": "English",
       "value": "en",
       "dir": "ltr",
       "disabled": false
     },
     {
+      "label": "Español",
+      "value": "es",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
       "label": "Euskara",
       "value": "eu",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
+      "label": "Gaeilge",
+      "value": "ga",
       "dir": "ltr",
       "disabled": false
     },
@@ -37,20 +55,50 @@
       "disabled": false
     },
     {
-      "label": "македонски",
-      "value": "mk",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
       "label": "Nederlands",
       "value": "nl",
       "dir": "ltr",
       "disabled": false
     },
     {
+      "label": "Polski",
+      "value": "pl",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
       "label": "Português",
       "value": "pt",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
+      "label": "Türkçe",
+      "value": "tr",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
+      "label": "македонски",
+      "value": "mk",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
+      "label": "پښتو",
+      "value": "ps",
+      "dir": "rtl",
+      "disabled": false
+    },
+    {
+      "label": "ਪੰਜਾਬੀ",
+      "value": "pa",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
+      "label": "中文（简体）",
+      "value": "zh-hans",
       "dir": "ltr",
       "disabled": false
     },
@@ -63,48 +111,6 @@
     {
       "label": "日本語",
       "value": "ja",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
-      "label": "Español",
-      "value": "es",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
-      "label": "Gaeilge",
-      "value": "ga",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
-      "label": "ਪੰਜਾਬੀ",
-      "value": "pa",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
-      "label": "Polski",
-      "value": "pl",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
-      "label": "پښتو",
-      "value": "ps",
-      "dir": "rtl",
-      "disabled": false
-    },
-    {
-      "label": "Türkçe",
-      "value": "tr",
-      "dir": "ltr",
-      "disabled": false
-    },
-    {
-      "label": "中文（简体）",
-      "value": "zh-hans",
       "dir": "ltr",
       "disabled": false
     }

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -6,52 +6,44 @@ const { cookies } = useCookies();
 
 const supportedLangs = displayLang.lang.map((language) => language.value);
 
-const importLangs = async (lang) => {
+// Dynamically import localisation messages.
+const importLang = async (lang) => {
   const locale = await import(`@/locale/${lang}.json`);
+
   return locale.default ?? locale;
 };
 
-const mapLangs = displayLang.lang.map(async (item) => {
-  const messages = await importLangs(item.value);
-
-  return {
-    ...item,
-    lang: messages,
-  };
-});
-
-const messages = Promise.all(mapLangs).then((results) =>
-  results.reduce((obj, item) => {
-    obj[item.value] = item.lang;
-    return obj;
-  }, {})
+// Import localisation messages for every language in displayLang.json.
+const messages = Object.fromEntries(
+  await Promise.all(
+    displayLang.lang.map(async ({ value }) => [
+      value,
+      await importLang(value),
+    ])
+  )
 );
 
 const getBrowserLanguage = () => {
   const browserLang = window.navigator.language.toLowerCase();
 
+  // Use the complete browser locale when it already matches a supported locale.
   if (supportedLangs.includes(browserLang)) {
     return browserLang;
   }
 
-  if (
-    browserLang === "zh" ||
-    browserLang === "zh-cn" ||
-    browserLang === "zh-sg" ||
-    browserLang.startsWith("zh-hans")
-  ) {
-    return "zh-hans";
+  // Determine the most likely Chinese script.
+  if (browserLang === "zh" || browserLang.startsWith("zh-")) {
+    try {
+      const locale = new Intl.Locale(browserLang).maximize();
+
+      return locale.script === "Hant" ? "zh-hant" : "zh-hans";
+    } catch {
+      return "zh-hans";
+    }
   }
 
-  if (
-    browserLang === "zh-tw" ||
-    browserLang === "zh-hk" ||
-    browserLang === "zh-mo" ||
-    browserLang.startsWith("zh-hant")
-  ) {
-    return "zh-hant";
-  }
-
+  // Match region-specific locales, such as de-DE or pt-BR,
+  // to their supported base language.
   const baseLang = browserLang.split("-")[0];
 
   return supportedLangs.includes(baseLang) ? baseLang : "en";
@@ -68,5 +60,5 @@ export const i18n = createI18n({
   globalInjection: true,
   locale: initialLocale,
   fallbackLocale: "en",
-  messages: await messages,
+  messages,
 });

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -4,42 +4,69 @@ import displayLang from "@/locale/displayLang.json";
 
 const { cookies } = useCookies();
 
-//Function for dynamically import localization datas
+const supportedLangs = displayLang.lang.map((language) => language.value);
 
 const importLangs = async (lang) => {
   const locale = await import(`@/locale/${lang}.json`);
-
-  return locale;
+  return locale.default ?? locale;
 };
 
-//Combine both display language array and imported localization datas
 const mapLangs = displayLang.lang.map(async (item) => {
-  const json = await importLangs(item.value);
+  const messages = await importLangs(item.value);
 
   return {
     ...item,
-    lang: json,
+    lang: messages,
   };
 });
 
-//Transform combined data into an accepted data object
-const messages = Promise.all(mapLangs).then(function (results) {
-  return results.reduce(
-    (obj, item) => ((obj[item.value] = item.lang), obj),
-    {}
-  );
-});
+const messages = Promise.all(mapLangs).then((results) =>
+  results.reduce((obj, item) => {
+    obj[item.value] = item.lang;
+    return obj;
+  }, {})
+);
 
 const getBrowserLanguage = () => {
-  const browserLang = window?.navigator?.language?.split("-")?.[0];
-  const supportedLangs = ["en", "es", "eu", "ga", "id", "ja", "lb", "min", "mk", "ms", "nl", "pa", "pl", "ps", "pt", "tr", "zh-hans", "zh-hant"];
-  return supportedLangs.includes(browserLang) ? browserLang : "en";
+  const browserLang = window.navigator.language.toLowerCase();
+
+  if (supportedLangs.includes(browserLang)) {
+    return browserLang;
+  }
+
+  if (
+    browserLang === "zh" ||
+    browserLang === "zh-cn" ||
+    browserLang === "zh-sg" ||
+    browserLang.startsWith("zh-hans")
+  ) {
+    return "zh-hans";
+  }
+
+  if (
+    browserLang === "zh-tw" ||
+    browserLang === "zh-hk" ||
+    browserLang === "zh-mo" ||
+    browserLang.startsWith("zh-hant")
+  ) {
+    return "zh-hant";
+  }
+
+  const baseLang = browserLang.split("-")[0];
+
+  return supportedLangs.includes(baseLang) ? baseLang : "en";
 };
+
+const cookieLocale = cookies?.get("locale");
+
+const initialLocale = supportedLangs.includes(cookieLocale)
+  ? cookieLocale
+  : getBrowserLanguage();
 
 export const i18n = createI18n({
   legacy: false,
   globalInjection: true,
-  locale: cookies?.get("locale") || getBrowserLanguage(),
+  locale: initialLocale,
   fallbackLocale: "en",
   messages: await messages,
 });


### PR DESCRIPTION
## Summary

- Add German (`de`) and Korean (`ko`) to the display language list.
- Use `displayLang.json` as the source of truth for supported languages.
- Add browser locale detection for Simplified and Traditional Chinese.
- Validate the saved locale cookie before using it.

## Why

The German and Korean localisation files already existed, but they were not available in the language selector or included in browser-language detection.

The supported language list was also maintained separately in `i18n.js`, which could become inconsistent with `displayLang.json` when new languages were added.

Chinese browser locales also require script-aware handling. Reducing values such as `zh-CN`, `zh-TW`, `zh-Hans`, or `zh-Hant` to the base language `zh` does not match either of the available Chinese localisation files.

## Changes

- Added German and Korean to `displayLang.json`.
- Replaced the hard-coded supported language array with values derived from `displayLang.lang`.
- Used `Intl.Locale.prototype.maximize()` to determine whether a Chinese browser locale most likely uses the Simplified or Traditional script.
- Mapped Chinese locales to either `zh-hans` or `zh-hant`.
- Added fallback handling for invalid or unrecognised Chinese locale values.
- Checked that the locale stored in the cookie is supported before using it.
- Kept English as the fallback locale when no supported browser or saved locale is available.