### PR TITLE
Release v1.6.1: Add fr and sk as display language

### DIFF
--- a/src/locale/displayLang.json
+++ b/src/locale/displayLang.json
@@ -37,6 +37,12 @@
       "disabled": false
     },
     {
+      "label": "Français",
+      "value": "fr",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
       "label": "Gaeilge",
       "value": "ga",
       "dir": "ltr",
@@ -69,6 +75,12 @@
     {
       "label": "Português",
       "value": "pt",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
+      "label": "Slovenčina",
+      "value": "sk",
       "dir": "ltr",
       "disabled": false
     },


### PR DESCRIPTION
## v1.6.1

### Localization

* Added French (`fr`) and Slovak (`sk`) to the display language list.
* Sync with the latest translatewiki update per 29 June 2026
