### PR TITLE
Release v1.6.2: Add fi as display language

### DIFF
--- a/src/locale/displayLang.json
+++ b/src/locale/displayLang.json
@@ -85,6 +85,12 @@
       "disabled": false
     },
     {
+      "label": "Suomi",
+      "value": "fi",
+      "dir": "ltr",
+      "disabled": false
+    },
+    {
       "label": "Türkçe",
       "value": "tr",
       "dir": "ltr",


### PR DESCRIPTION
## v1.6.2

### Localization

* Added Suomi (fi) to the display language list.
* Sync with the latest translatewiki update per 20 July 2026